### PR TITLE
Feature/release-workflow

### DIFF
--- a/.github/workflows/main-tag-release.yml
+++ b/.github/workflows/main-tag-release.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  release-on-push:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: minor


### PR DESCRIPTION
Add GitHub action to automatically create a tag and a release for every pr on the main branch.

See [here](https://github.com/marketplace/actions/tag-release-on-push-action) for more details.